### PR TITLE
fix current cpu filtering by instance

### DIFF
--- a/pkg/googlecloud/googlecloud.go
+++ b/pkg/googlecloud/googlecloud.go
@@ -61,7 +61,7 @@ func (m *googleCloudClient) GetCurrentCPULoad() (int32, error) {
 	endTime := time.Now().UTC()
 	request := &monitoringpb.ListTimeSeriesRequest{
 		Name:   "projects/" + m.projectID,
-		Filter: `metric.type="bigtable.googleapis.com/cluster/cpu_load"`,
+		Filter: fmt.Sprintf(`metric.type="bigtable.googleapis.com/cluster/cpu_load" resource.type="bigtable_cluster" resource.label."instance"="%s"`, m.instanceID),
 		Interval: &monitoringpb.TimeInterval{
 			StartTime: &timestamp.Timestamp{
 				Seconds: startTime.Unix(),


### PR DESCRIPTION
The request to retrieve the CPU might return time series from other instances and will just return the first one. I've added a filter using the instance ID